### PR TITLE
update `lapply` in `end_round`

### DIFF
--- a/R/end_round.R
+++ b/R/end_round.R
@@ -20,10 +20,10 @@ end_round = function(paths,hideouts=NULL){
   #' possibilities = take_a_step(possibilities,roads)
   #' hideouts = end_round(possibilities,hideouts=hideouts)
 
-  possible_hideouts = lapply(paths,function(x){
-    rev(x)[1]
-  })
-  possible_hideouts = unique(unlist(possible_hideouts))
+  possible_hideouts = vapply(paths, function(x){
+    x[length(x)]
+  }, numeric(1))
+  possible_hideouts = unique(possible_hideouts)
   if(is.null(hideouts)) return(sort(possible_hideouts))
   hideouts = intersect(hideouts,possible_hideouts)
   return(sort(hideouts))


### PR DESCRIPTION
#hacktoberfest

Overview: verrrry minimal performance improvement for subsetting last element of vector; additionally, converted an `lapply` to a `vapply` to avoid subsequent call to `unlist`.

Full details:

```r
library(whitechapelR)

# SETUP FROM EXAMPLE IN end_round
possibilities = start_round(64)
possibilities = take_a_step(possibilities,roads)
possibilities = take_a_step(possibilities,roads,blocked=list(c(63,82),c(63,65)))
possibilities = inspect_space(possibilities,space = c(29,30), clue = FALSE)
possibilities = inspect_space(possibilities,space = 49, clue = TRUE)
hideouts = end_round(possibilities,hideouts=NULL)
possibilities = start_round(67)
possibilities = take_a_step(possibilities,roads)
#-------------------------------------------------------------------------------------

# COMPARISON OF FULL OLD AND NEW METHODS (added unlist since it is required in current workflow)
possible_hideouts = unlist(lapply(possibilities, function(x){
  rev(x)[1]
}))

possible_hideouts_new = vapply(possibilities, function(x){
  x[length(x)]
}, numeric(1))

microbenchmark::microbenchmark(possible_hideouts,
                               possible_hideouts_new, 
                               times = 10000)

# Unit: nanoseconds
#                  expr min lq    mean median uq  max neval
#     possible_hideouts  29 31 33.6995     32 32 7047 10000
# possible_hideouts_new  27 29 30.8432     30 31  785 10000
#-------------------------------------------------------------------------------------

# COMPARISON OF ONLY SUBSETTING CHANGE
x = sample(1000)

microbenchmark::microbenchmark(rev(x)[1],
                               tail(x, 1),
                               x[length(x)],
                               times = 10000)

# Unit: nanoseconds
#         expr   min    lq      mean median    uq     max neval
#    rev(x)[1]  3650  4081  5012.961   4423  4658 3528685 10000
#   tail(x, 1) 12321 13257 14965.617  13701 14682 2925085 10000
# x[length(x)]   147   184   242.509    224   268    6522 10000
#-------------------------------------------------------------------------------------
```